### PR TITLE
Fix deps for `wrenidm` (6.0.0-SNAPSHOT)

### DIFF
--- a/src/main/resources/trustedkeys.properties
+++ b/src/main/resources/trustedkeys.properties
@@ -3,7 +3,6 @@ external:esapiport:2013-12-04=0xD7F749B5
 external:jaxrpc-impl:1.1.3_01-041406=0xD7F749B5
 external:jdmktk:2007-01-10=0xD7F749B5
 external:jss4:2007-08-11=0xD7F749B5
-org.postgresql:postgresql-fr-osgi:9.3-1101-jdbc41=0xD7F749B5
 
 # Xerces-J dependencies inherited from Sun / ForgeRock
 xerces-J:xercesImpl:2.11.0=0xD7F749B5
@@ -763,6 +762,7 @@ org.ow2.asm:asm-commons:5.0.4=0x5F69AD087600B22C
 org.ow2.asm:asm-tree:4.1=0x5F69AD087600B22C
 org.ow2.asm:asm-tree:5.0.4=0x5F69AD087600B22C
 org.ow2.asm:asm-util:4.1=0x5F69AD087600B22C
+org.postgresql:postgresql:42.2.14.jre7=0x105CB91CAC2AEE0E
 org.powermock:powermock-api-easymock:1.5=0x368557390486F2C5
 org.powermock:powermock-api-mockito:1.5=0x368557390486F2C5
 org.powermock:powermock-api-support:1.5=0x368557390486F2C5


### PR DESCRIPTION
Updates signature for _PostgreSQL_.