### PR TITLE
Remove version restriction for commons-fileupload.

### DIFF
--- a/src/main/resources/wrensec-trusted-keys.list
+++ b/src/main/resources/wrensec-trusted-keys.list
@@ -202,7 +202,7 @@ commons-collections             = 0x0CC641C3A62453AB390066C4A41F13C999945293, \
 commons-digester                = 0xA9F885A21BA0EFB7D0991E6CCAF5EC5919FEA27D
 commons-digester:*:1.8          = noSig
 commons-discovery               = 0xA9F885A21BA0EFB7D0991E6CCAF5EC5919FEA27D
-commons-fileupload:*:1.3.1      = 0xA9C5DF4D22E99998D9875A5110C01C5A2F6059E7
+commons-fileupload              = 0xA9C5DF4D22E99998D9875A5110C01C5A2F6059E7
 commons-io                      = 0x2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB, \
                                   0x6BDACA2C0493CCA133B372D09C4F7E9D98B1CC53, \
                                   0xCD5464315F0B98C77E6E8ECD9DAADC1C9FCC82D0


### PR DESCRIPTION
I have removed the version restriction for `commons-fileupload` to allow an upgrade to version 1.5.